### PR TITLE
Feature/eoepca 68

### DIFF
--- a/travis/acceptanceTest.sh
+++ b/travis/acceptanceTest.sh
@@ -4,10 +4,11 @@
 set -euov pipefail
 
 # Check presence of environment variables
-TRAVIS_BRANCH="${TRAVIS_BRANCH:-develop}"
 TRAVIS_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER:-0}"
 
-docker run --rm -d -p 8080:7000 --name template-svc ${DOCKER_USERNAME}/template-service:travis_${TRAVIS_BRANCH}_${TRAVIS_BUILD_NUMBER}
+buildTag=travis_$TRAVIS_BUILD_NUMBER # We use a temporary build number for tagging, since this is a transient artefact
+
+docker run --rm -d -p 8080:7000 --name template-svc eoepca/template-service:${buildTag} # Runs container from EOEPCA repository
 
 sleep 15 # wait until the container is running
 

--- a/travis/containerCreation.sh
+++ b/travis/containerCreation.sh
@@ -6,12 +6,11 @@ set -euov pipefail
 ./gradlew shadowJar
 
 # Check presence of environment variables
-TRAVIS_BRANCH="${TRAVIS_BRANCH:-develop}"
 TRAVIS_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER:-0}"
 
 
 # Create a Docker image and tag it as 'travis_<build number>'
-buildTag=travis_${TRAVIS_BRANCH}_$TRAVIS_BUILD_NUMBER
+buildTag=travis_$TRAVIS_BUILD_NUMBER # We use a temporary build number for tagging, since this is a transient artefact
 
 docker build -t eoepca/template-service .
 docker tag eoepca/template-service eoepca/template-service:$buildTag # Tags container in EOEPCA repository with buildTag

--- a/travis/containerCreation.sh
+++ b/travis/containerCreation.sh
@@ -14,8 +14,8 @@ TRAVIS_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER:-0}"
 buildTag=travis_${TRAVIS_BRANCH}_$TRAVIS_BUILD_NUMBER
 
 docker build -t eoepca/template-service .
-docker tag eoepca/template-service $DOCKER_USERNAME/template-service:$buildTag
+docker tag eoepca/template-service eoepca/template-service:$buildTag # Tags container in EOEPCA repository with buildTag
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-docker push $DOCKER_USERNAME/template-service:$buildTag   # defaults to docker hub
+docker push eoepca/template-service:$buildTag   # defaults to docker hub EOEPCA repository


### PR DESCRIPTION
This feature makes the template-svce to publish all docker container artefacts in the same EOEPCA repository (while allowing to use different hub.docker.com accounts).

It also simplifies the tag, removing the branch information, since they are -at this point- only transient artefacts, to be deleted after while. Sample tag is: eoepca/template-svce:travis_122

This pull request is also a good trial for the defined configuration management process.